### PR TITLE
I've updated the planning documents for V1.0.4 to focus on the first …

### DIFF
--- a/plans/0_backlog/feature-idea.md
+++ b/plans/0_backlog/feature-idea.md
@@ -31,10 +31,10 @@ These features have been fully implemented and moved to the completed section of
 
 These features are still in the idea stage and have not yet been planned or implemented:
 
-- **Use cookies to track exact section and quiz completion** (V1.0.4)
-  - Store in cookies the exact sections the user has read and the exact quizzes completed, including their answers.
-  - When the user enters the training page, the app will read the cookie and automatically tick checkboxes for all sections they have read and restore answers for all quizzes they have previously attempted.
-  - This enables persistent, granular progress tracking for both sections and quizzes, supporting richer feedback and future features.
+- **Use cookies to track completion of the first training question** (V1.0.4)
+  - As an initial step for V1.0.4, implement cookie-based tracking for whether the user has completed the *first question* of the training page.
+  - When the user revisits the training page, the app will read this cookie and visually indicate if the first question was previously completed.
+  - This will serve as a pilot for the broader feature of tracking all sections and quizzes.
 
 - **Display app version in menu bar** (V1.0.5)
   - Show the current application version in small font somewhere in the menu bar for quick reference and improved transparency for users and developers.

--- a/plans/1_planning/V1.0.4/README.md
+++ b/plans/1_planning/V1.0.4/README.md
@@ -3,14 +3,13 @@
 **Version:** V1.0.4
 
 ## Goal
-Use cookies to track the exact sections that have been read and quizzes that have been completed by the user. When the user enters the training page, the app will read the cookie and automatically tick checkboxes for all sections they have read and restore answers for all quizzes they have previously attempted.
+As an initial implementation for V1.0.4, use cookies to track whether the *first question* in the training page has been completed by the user. When the user revisits the training page, the app will read this cookie and visually indicate if the first question was previously completed. This will serve as a pilot for potentially broader progress tracking.
 
 ## Key Requirements
-- Track exactly which sections a user has read and which quizzes (and answers) they have completed.
-- Store section and quiz state in cookies for persistence.
-- When entering the training page, restore all previously read sections as checked and restore quiz answers.
-- Integrate with feedback and achievement UI.
-- Enable future migration to server-side tracking if needed.
+- Track whether the *first question* of the training page has been completed.
+- Store this completion state in a cookie for persistence.
+- When the user enters the training page, restore the visual indication of the first question's completion status based on the cookie.
+- Ensure this initial implementation can be extended for more granular tracking (all sections/quizzes) in the future.
 
 ## Target Audience
 - End users (trainees) taking quizzes.

--- a/plans/1_planning/V1.0.4/design.md
+++ b/plans/1_planning/V1.0.4/design.md
@@ -1,22 +1,25 @@
-# Design Notes: Quiz Completion Cookies
+# Design Notes: First Question Completion Cookie
 
 **Version:** V1.0.4
 
-- Use cookies to track exactly which sections a user has read and which quizzes (and answers) they have completed.
-- When the user enters the training page, the app will read the cookie and automatically tick checkboxes for all sections they have read and restore answers for all quizzes they have previously attempted.
-- Store section and quiz state in cookies for persistence.
-- Integrate with feedback and achievement UI.
-- Enable future migration to server-side tracking if needed.
-- Allow a reset button to clear quiz progress.
-- Visual sketch:
-
+- **Objective**: Track the completion status of only the *first question* in the training page.
+- **Mechanism**:
+    - A specific cookie, e.g., `training_first_question_done`, will store a boolean value (`true`/`false`).
+    - Alternatively, a general progress cookie (e.g., `training_progress`) could store a JSON object, and a key like `first_question_completed: true` would be used. For this initial step, a dedicated cookie is simpler.
+- **Behavior**:
+    - On completion of the first question (e.g., user clicks "Submit" or "Show Answer" for the first question), the cookie will be set to `true`.
+    - When the training page loads, the application will check for this cookie.
+    - If the cookie exists and is `true`, a visual indicator (e.g., a checked box, a different styling for the question) will show that the first question has already been addressed.
+- **Visual Sketch**:
 ```
-[User completes quiz] → [Update cookie: add quiz ID + score]
+[User interacts with first question (e.g., submits answer)] → [Set cookie 'training_first_question_done' to 'true']
         ↓
-[On load: read cookie → update UI]
+[On training page load: read cookie 'training_first_question_done'] → [If 'true', update UI for first question]
 ```
-
-- Component interactions:
-  - Frontend updates and reads cookies.
-  - Backend may read for analytics if needed in future.
-- Consider extensibility for new quizzes or scoring methods.
+- **Component Interactions**:
+  - Frontend JavaScript will be responsible for setting and reading this specific cookie.
+  - No backend interaction is required for this specific feature increment.
+- **Extensibility**:
+  - While this focuses on the first question, the approach can be extended by using a more complex cookie structure (like the JSON object mentioned above) if the feature expands to track all questions/sections.
+- **Reset**:
+  - A general "reset training progress" function could clear this cookie along with others. For now, specific reset for just this flag is not a primary concern but can be achieved by clearing the specific cookie.

--- a/plans/1_planning/V1.0.4/spec.md
+++ b/plans/1_planning/V1.0.4/spec.md
@@ -3,17 +3,19 @@
 **Version:** V1.0.4
 
 ## Intended Functionality
-- Use cookies to track exactly which sections a user has read and which quizzes (and answers) they have completed.
-- When the user enters the training page, the app will read the cookie and automatically tick checkboxes for all sections they have read and restore answers for all quizzes they have previously attempted.
-- Store section and quiz state in cookies for persistence.
-- Integrate with the feedback and achievement UI.
-- Support future migration to server-side tracking if needed.
-- Optionally, allow user to reset quiz progress (clear cookie).
+- Use a cookie to track whether the *first question* in the training page has been completed by the user.
+- When the user revisits the training page, the app will read this cookie.
+- If the cookie indicates completion, the UI will visually reflect that the first question has been previously addressed (e.g., checkbox ticked, section expanded, or a specific message).
+- Store this completion state in a cookie for persistence.
+- This functionality serves as an initial step and should be designed for potential future expansion to cover all questions and sections.
+- A user-initiated reset of progress should clear this cookie.
 
 ## Technical Scope
-- Use `document.cookie` for persistence.
-- Cookie value: JSON object mapping quiz IDs to scores/completion state.
-- Update cookie on quiz completion event.
+- Use `document.cookie` for persistence on the client-side.
+- Cookie name: A dedicated name, for example, `training_first_question_completed`.
+- Cookie value: A simple boolean representation (e.g., 'true' or '1').
+- The cookie will be set (or updated) when the user completes an action indicating the first question is done (e.g., submitting an answer, revealing the answer for the first question).
+- JavaScript will handle reading this cookie on page load to update the UI.
 
 ## UI Treatments / Layout Options
 1. **Quiz completion checklist:**


### PR DESCRIPTION
…question cookie. This refines the scope of V1.0.4 to initially focus on tracking the completion of the first training question using a cookie. I've updated feature-idea.md, and V1.0.4/README.md, V1.0.4/design.md, and V1.0.4/spec.md to reflect this specific plan.